### PR TITLE
Running NuttX CI with Self-Hosted Runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,13 +117,14 @@ jobs:
 
   Linux:
     needs: Fetch-Source
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, Linux, ARM64]
     env:
       DOCKER_BUILDKIT: 1
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
+        # boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
+        boards: [sim-01, sim-02]
 
     steps:
       - name: Download Source Artifact
@@ -175,7 +176,7 @@ jobs:
   macOS:
     permissions:
       contents: none
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, macOS, X64]
     needs: Fetch-Source
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   Fetch-Source:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, macOS]
     steps:
       - name: Determine Target Branches
         id: gittargets
@@ -117,7 +117,7 @@ jobs:
 
   Linux:
     needs: Fetch-Source
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, Linux]
     env:
       DOCKER_BUILDKIT: 1
 
@@ -175,7 +175,7 @@ jobs:
   macOS:
     permissions:
       contents: none
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, macOS]
     needs: Fetch-Source
     strategy:
       matrix:
@@ -222,7 +222,7 @@ jobs:
 
   msys2:
     needs: Fetch-Source
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, Windows]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,63 +115,63 @@ jobs:
           name: source-bundle
           path: sources.tar.gz
 
-  Linux:
-    needs: Fetch-Source
-    runs-on: [self-hosted, Linux, ARM64]
-    env:
-      DOCKER_BUILDKIT: 1
+  #### TODO: Needs Linux x64 because of Docker
+  # Linux:
+  #   needs: Fetch-Source
+  #   runs-on: [self-hosted, Linux, X64]
+  #   env:
+  #     DOCKER_BUILDKIT: 1
 
-    strategy:
-      matrix:
-        # boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
-        boards: [sim-01, sim-02]
+  #   strategy:
+  #     matrix:
+  #       boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
 
-    steps:
-      - name: Download Source Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: source-bundle
-          path: .
+  #   steps:
+  #     - name: Download Source Artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: source-bundle
+  #         path: .
 
-      - name: Extract sources
-        run: tar zxf sources.tar.gz
+  #     - name: Extract sources
+  #       run: tar zxf sources.tar.gz
 
-      - name: Docker Login
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Docker Login
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker Pull
-        run: docker pull ghcr.io/apache/nuttx/apache-nuttx-ci-linux
+  #     - name: Docker Pull
+  #       run: docker pull ghcr.io/apache/nuttx/apache-nuttx-ci-linux
 
-      - name: Export NuttX Repo SHA
-        run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
+  #     - name: Export NuttX Repo SHA
+  #       run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
 
-      - name: Run builds
-        uses: ./sources/nuttx/.github/actions/ci-container
-        env:
-          BLOBDIR: /tools/blobs
-        with:
-          run: |
-            echo "::add-matcher::sources/nuttx/.github/gcc.json"
-            export ARTIFACTDIR=`pwd`/buildartifacts
-            git config --global --add safe.directory /github/workspace/sources/nuttx
-            git config --global --add safe.directory /github/workspace/sources/apps
-            cd sources/nuttx/tools/ci
-            if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
-                ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat
-            else
-                ./cibuild.sh -c -A -N -R testlist/${{matrix.boards}}.dat
-            fi
+  #     - name: Run builds
+  #       uses: ./sources/nuttx/.github/actions/ci-container
+  #       env:
+  #         BLOBDIR: /tools/blobs
+  #       with:
+  #         run: |
+  #           echo "::add-matcher::sources/nuttx/.github/gcc.json"
+  #           export ARTIFACTDIR=`pwd`/buildartifacts
+  #           git config --global --add safe.directory /github/workspace/sources/nuttx
+  #           git config --global --add safe.directory /github/workspace/sources/apps
+  #           cd sources/nuttx/tools/ci
+  #           if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
+  #               ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat
+  #           else
+  #               ./cibuild.sh -c -A -N -R testlist/${{matrix.boards}}.dat
+  #           fi
 
-      - uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: linux-${{matrix.boards}}-builds
-          path: buildartifacts/
-        continue-on-error: true
+  #     - uses: actions/upload-artifact@v4
+  #       if: ${{ always() }}
+  #       with:
+  #         name: linux-${{matrix.boards}}-builds
+  #         path: buildartifacts/
+  #       continue-on-error: true
 
   macOS:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,63 +115,62 @@ jobs:
           name: source-bundle
           path: sources.tar.gz
 
-  #### TODO: Needs Linux x64 because of Docker
-  # Linux:
-  #   needs: Fetch-Source
-  #   runs-on: [self-hosted, Linux, X64]
-  #   env:
-  #     DOCKER_BUILDKIT: 1
+  Linux:
+    needs: Fetch-Source
+    runs-on: [self-hosted, Linux, X64]
+    env:
+      DOCKER_BUILDKIT: 1
 
-  #   strategy:
-  #     matrix:
-  #       boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
+    strategy:
+      matrix:
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
 
-  #   steps:
-  #     - name: Download Source Artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: source-bundle
-  #         path: .
+    steps:
+      - name: Download Source Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: source-bundle
+          path: .
 
-  #     - name: Extract sources
-  #       run: tar zxf sources.tar.gz
+      - name: Extract sources
+        run: tar zxf sources.tar.gz
 
-  #     - name: Docker Login
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Docker Pull
-  #       run: docker pull ghcr.io/apache/nuttx/apache-nuttx-ci-linux
+      - name: Docker Pull
+        run: docker pull ghcr.io/apache/nuttx/apache-nuttx-ci-linux
 
-  #     - name: Export NuttX Repo SHA
-  #       run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
+      - name: Export NuttX Repo SHA
+        run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
 
-  #     - name: Run builds
-  #       uses: ./sources/nuttx/.github/actions/ci-container
-  #       env:
-  #         BLOBDIR: /tools/blobs
-  #       with:
-  #         run: |
-  #           echo "::add-matcher::sources/nuttx/.github/gcc.json"
-  #           export ARTIFACTDIR=`pwd`/buildartifacts
-  #           git config --global --add safe.directory /github/workspace/sources/nuttx
-  #           git config --global --add safe.directory /github/workspace/sources/apps
-  #           cd sources/nuttx/tools/ci
-  #           if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
-  #               ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat
-  #           else
-  #               ./cibuild.sh -c -A -N -R testlist/${{matrix.boards}}.dat
-  #           fi
+      - name: Run builds
+        uses: ./sources/nuttx/.github/actions/ci-container
+        env:
+          BLOBDIR: /tools/blobs
+        with:
+          run: |
+            echo "::add-matcher::sources/nuttx/.github/gcc.json"
+            export ARTIFACTDIR=`pwd`/buildartifacts
+            git config --global --add safe.directory /github/workspace/sources/nuttx
+            git config --global --add safe.directory /github/workspace/sources/apps
+            cd sources/nuttx/tools/ci
+            if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
+                ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat
+            else
+                ./cibuild.sh -c -A -N -R testlist/${{matrix.boards}}.dat
+            fi
 
-  #     - uses: actions/upload-artifact@v4
-  #       if: ${{ always() }}
-  #       with:
-  #         name: linux-${{matrix.boards}}-builds
-  #         path: buildartifacts/
-  #       continue-on-error: true
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: linux-${{matrix.boards}}-builds
+          path: buildartifacts/
+        continue-on-error: true
 
   macOS:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   Fetch-Source:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     steps:
       - name: Determine Target Branches
         id: gittargets
@@ -117,7 +117,7 @@ jobs:
 
   Linux:
     needs: Fetch-Source
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     env:
       DOCKER_BUILDKIT: 1
 
@@ -175,7 +175,7 @@ jobs:
   macOS:
     permissions:
       contents: none
-    runs-on: macos-13
+    runs-on: [self-hosted]
     needs: Fetch-Source
     strategy:
       matrix:
@@ -222,7 +222,7 @@ jobs:
 
   msys2:
     needs: Fetch-Source
-    runs-on: windows-latest
+    runs-on: [self-hosted]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,9 +204,10 @@ jobs:
 
       # Released version of Cython has issues with Python 11. Set runner to use Python 3.10
       # https://github.com/cython/cython/issues/4500
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+      # TODO: This hangs on macOS Arm64
+      # - uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.10'
       - name: Run Builds
         run: |
           echo "::add-matcher::sources/nuttx/.github/gcc.json"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   Fetch-Source:
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Determine Target Branches
         id: gittargets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
   macOS:
     permissions:
       contents: none
-    runs-on: [self-hosted, macOS, X64]
+    runs-on: [self-hosted, macOS, ARM64]
     needs: Fetch-Source
     strategy:
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
 
     steps:
       - name: Checkout nuttx repo

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,12 +25,13 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
+      # TODO: This hangs on macOS Arm64
+      # - uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.8'
       - name: Install LaTeX packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, macOS, X64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,12 +25,13 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, ARM64]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
+      # TODO: This fails on Linux Arm64
+      # - uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.8'
       - name: Install LaTeX packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,13 +25,12 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
-      # TODO: This hangs on macOS Arm64
-      # - uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.8'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
       - name: Install LaTeX packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,13 +25,12 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
-      # TODO: This fails on Linux Arm64
-      # - uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.8'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
       - name: Install LaTeX packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, Linux, ARM64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build-html:
-    runs-on: [self-hosted, macOS, X64]
+    runs-on: [self-hosted, Linux, ARM64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read  # for actions/checkout to fetch code
       statuses: write  # for github/super-linter to mark status of each linter run
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read  # for actions/checkout to fetch code
       statuses: write  # for github/super-linter to mark status of each linter run
     name: Lint
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, Linux, ARM64]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+test runner
 <p align="center">
 <img src="https://raw.githubusercontent.com/apache/nuttx/master/Documentation/_static/NuttX320.png" width="175">
 </p>


### PR DESCRIPTION
![](https://lupyuen.github.io/images/nuttx-ci.jpg)

## Running NuttX CI with Self-Hosted Runners

Read the article: https://github.com/lupyuen/lupyuen.github.io/blob/master/src/ci.md

Let's test NuttX CI with Self-Hosted Runners on macOS Arm64 and Ubuntu x64:
- I have a super powerful Mac Mini Arm64 that's under utilised
- And an old MacBook Pro on Ubuntu x64 (24.04 LTS)
- Plenty of bandwidth at home: [Fibre To The Home](http://speedtestsg.speedtestcustom.com/result/ca95c5c0-64eb-11ef-982f-dfa9296e96b3) with Downlink 650 Mbps, Uplink 560 Mbps
- [Follow these instructions](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners) to install Self-Hosted Runners for macOS Arm64 and Linux x64
- Start a few instances of each runner. Each instance needs its own `actions-runner` folder. TODO: How to handle `/github`?
- See below for the fixes for macOS Arm64 and Linux x64
- Security Concerns: How to be sure that Self-Hosted Runners will run only approved scripts and commands?
  (Right now I have disabled external users from triggering GitHub Actions on my repo)

We modified the GitHub Workflow Files, to use Self-Hosted Runners:
- https://github.com/lupyuen3/runner-nuttx/pull/1/files

Why are we doing this?
- In case we need to reduce [GitHub Hosting Costs](https://docs.google.com/spreadsheets/d/1gY0VrSJvouXwDIclspQCFoBcoHhNCbGicNoVJRhJ-h4/edit?gid=0#gid=0). Or if we need to run the NuttX CI privately.
- It's a great way to understand the Internals of NuttX CI!
- Why is NuttX CI so heavy? That's because for every PR, it compiles every single NuttX Build Config: Arm, RISC-V, Simulator. (Hosting charges won't be cheap)

TODO: We might need a quicker way to "fail fast" and prevent other CI Jobs from running? Which will reduce the number of Runners?

TODO: What if we could start earlier the CI Jobs that are impacted by the Modified Code in the PR? So if I modify something for Ox64 BL808 SBC, it should start the CI Job for `ox64:nsh`. If it fails, then don't bother with the rest of the Arm / RISC-V / Simulator jobs.

TODO: Suppose we need to throttle our GitHub Runners from 36 Runners down to 25 Runners (and cut costs). What would be the impact on NuttX CI Duration? Are there any tools for modeling the queueing duration? 

### CI Build for NuttX

_Our Self-Hosted Runners: Do they work for NuttX CI Builds?_

Here's the result: https://github.com/lupyuen3/runner-nuttx/actions

- [`Fetch Source`](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440434/job/29343582486) works OK on macOS Arm64

- Most of the [Linux Builds](https://github.com/lupyuen3/runner-nuttx/actions/workflows/build.yml) won't work on macOS Arm64 because they need Docker on Linux x64 

- Podman Docker on Linux x64 [fails with this error](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440489/job/29343575677). Might be a [problem with Podman](https://github.com/containers/podman/discussions/14238).
  ```text
  Writing manifest to image destination
  Error: statfs /var/run/docker.sock: permission denied
  ```

- Retested with Docker Engine, which [fails with this error](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440434/job/29344966455):
  ```text
  permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.47/images/create?fromImage=ghcr.io%2Fapache%2Fnuttx%2Fapache-nuttx-ci-linux&tag=latest": dial unix /var/run/docker.sock: connect: permission denied
   ```

  We apply [this Docker Fix](https://stackoverflow.com/questions/48957195/how-to-fix-docker-got-permission-denied-issue). 

  And [it works yay](https://github.com/lupyuen3/runner-nuttx/actions/runs/10591125185/job/29349060343)! (2 hours on a 10-year-old MacBook Pro with Core i7)

- Docker Website will throttle our downloading of Docker Images. If it gets too slow, cancel the GitHub Workflow and restart. Throttling will magically disappear.

- [`Build macOS (macos / sim-01 / sim-02)`](https://github.com/lupyuen3/runner-nuttx/actions/workflows/build.yml) on macOS Arm64: `setup-python` will [hang because it's prompting for password](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440434/job/29343630883). So we comment out `setup-python`.

  ```text
  Run actions/setup-python@v5
  Installed versions
  Version 3.[8](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440489/job/29343575677#step:3:9) was not found in the local cache
  Version 3.8 is available for downloading
  Download from "https://github.com/actions/python-versions/releases/download/3.8.10-887[9](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440489/job/29343575677#step:3:10)978422/python-3.8.10-darwin-arm64.tar.gz"
  Extract downloaded archive
  /usr/bin/tar xz -C /Users/luppy/actions-runner2/_work/_temp/2e[13](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440489/job/29343575677#step:3:14)8b05-b7c9-4759-956a-7283af148721 -f /Users/luppy/actions-runner2/_work/_temp/792ffa3a-a28f-4443-91c8-0d81f55e422f
  Execute installation script
  Check if Python hostedtoolcache folder exist...
  Install Python binaries from prebuilt package
  ```
  Then it fails while [downloading the toolchain](https://github.com/lupyuen3/runner-nuttx/actions/runs/10591125185/job/29349061179)
  ```text
  + wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz
  + xz -d arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz
  xz: arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz: Unexpected end of input
  ```
  Retry and it [fails at objcopy sigh](https://github.com/lupyuen3/runner-nuttx/actions/runs/10594022857/job/29359739769):
  ```text
  + rm -f /Users/luppy/actions-runner3/_work/runner-nuttx/runner-nuttx/sources/tools/bintools/bin/objcopy
  + ln -s /usr/local/opt/binutils/bin/objcopy /Users/luppy/actions-runner3/_work/runner-nuttx/runner-nuttx/sources/tools/bintools/bin/objcopy
  + command objcopy --version
  + objcopy --version
  /Users/luppy/actions-runner3/_work/runner-nuttx/runner-nuttx/sources/nuttx/tools/ci/platforms/darwin.sh: line 93: objcopy: command not found
  ```
  TODO: Do we change the toolchain from x64 to Arm64?

_Can we guesstimate the time to run a CI Build?_

Just browse the GitHub Actions Log for the CI Build. See the Line Numbers? Every NuttX CI Build will have roughly 1,000 lines of log (by sheer coincidence). We can use this to guess the CI Build Duration.

### Documentation Build for NuttX

_Does it work for Documentation Build?_

- [`Documentation`](https://github.com/lupyuen3/runner-nuttx/actions/workflows/doc.yml) on macOS Arm64: [Hangs at setup-python](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440489/job/29343575677) because it prompts for password:
  ```text
  Run actions/setup-python@v5
  Installed versions
  Version 3.[8](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440489/job/29343575677#step:3:9) was not found in the local cache
  Version 3.8 is available for downloading
  Download from "https://github.com/actions/python-versions/releases/download/3.8.10-887[9](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440489/job/29343575677#step:3:10)978422/python-3.8.10-darwin-arm64.tar.gz"
  Extract downloaded archive
  /usr/bin/tar xz -C /Users/luppy/actions-runner2/_work/_temp/2e[13](https://github.com/lupyuen3/runner-nuttx/actions/runs/10589440489/job/29343575677#step:3:14)8b05-b7c9-4759-956a-7283af148721 -f /Users/luppy/actions-runner2/_work/_temp/792ffa3a-a28f-4443-91c8-0d81f55e422f
  Execute installation script
  Check if Python hostedtoolcache folder exist...
  Install Python binaries from prebuilt package
  ```
  And it won't work on macOS because it needs `apt`: [workflows/doc.yml](https://github.com/lupyuen3/runner-nuttx/blob/master/.github/workflows/doc.yml#L34-L40)
  ```yaml
      - name: Install LaTeX packages
        run: |
          sudo apt-get update -y
          sudo apt-get install -y \
            texlive-latex-recommended texlive-fonts-recommended \
            texlive-latex-base texlive-latex-extra latexmk texlive-luatex \
            fonts-freefont-otf xindy
  ```

- [`Documentation`](https://github.com/lupyuen3/runner-nuttx/actions/workflows/doc.yml) on Linux Arm64:  [Fails at setup-python](https://github.com/lupyuen3/runner-nuttx/actions/runs/10590973119/job/29347607289)
  ```text
  Run actions/setup-python@v5
  Installed versions
  Version 3.[8](https://github.com/lupyuen3/runner-nuttx/actions/runs/10590973119/job/29347607289#step:3:9) was not found in the local cache
  Error: The version '3.8' with architecture 'arm64' was not found for Debian 12.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
  ```
  So we comment out `setup-python`. Then it fails with [pip3 not found](https://github.com/lupyuen3/runner-nuttx/actions/runs/10593895809/job/29356477035):
  ```text
  pip3: command not found
  ```
  TODO: Switch to pipenv

- [`Documentation`](https://github.com/lupyuen3/runner-nuttx/actions/workflows/doc.yml) on Linux x64: [Fails with rmdir error](https://github.com/lupyuen3/runner-nuttx/actions/runs/10591125174/job/29348045745)
  ```text
  Copying '/home/luppy/.gitconfig' to '/home/luppy/actions-runner/_work/_temp/8c370e2f-3f8f-4e01-b8f2-1ccb301640a1/.gitconfig'
  Temporarily overriding HOME='/home/luppy/actions-runner/_work/_temp/8c370e2f-3f8f-4e01-b8f2-1ccb301640a1' before making global git config changes
  Adding repository directory to the temporary git global config as a safe directory
  /usr/bin/git config --global --add safe.directory /home/luppy/actions-runner/_work/runner-nuttx/runner-nuttx
  Deleting the contents of '/home/luppy/actions-runner/_work/runner-nuttx/runner-nuttx'
  Error: File was unable to be removed Error: EACCES: permission denied, rmdir '/home/luppy/actions-runner/_work/runner-nuttx/runner-nuttx/buildartifacts/at32f437-mini'
  ```
  TODO: Check the rmdir directory

### UTM Emulator for macOS Arm64

_So NuttX CI works better with a huge x64 Ubuntu PC. Can we make macOS on Arm64 more useful?_

- Now testing [UTM Emulator for macOS Arm64](https://mac.getutm.app/), to emulate Ubuntu x64 (because my MacBook Pro x64 is running too hot and slow). 

  Here's our Emulated Ubuntu x64 24.04.1 LTS with 4GB RAM: [Build for arm-01](https://github.com/lupyuen3/runner-nuttx/actions/runs/10594022857/job/29503152279), [Build for arm-02](https://github.com/lupyuen3/runner-nuttx/actions/runs/10594022857/job/29508376208), [Build for arm-03](https://github.com/lupyuen3/runner-nuttx/actions/runs/10594022857/job/29428211466), [Build for arm-04](https://github.com/lupyuen3/runner-nuttx/actions/runs/10594022857/job/29456380032)

  Does it work? Yes! How many hours? 4 hours! (Instead of 33 mins when hosted at GitHub)

  TODO: Do we run multiple Virtual Machines in macOS UTM?

- Alternatively: Running a Self-Hosted Runner inside a Docker Container (Rancher Desktop) on macOS Arm64

  But Then: It becomes a Linux Arm64 Runner, not a Linux x64 Runner. Which won't work with our current NuttX CI Docker Image, which is x64 only.

  Unless: We create a Linux Arm64 Docker Image for NuttX CI? Like for [Compiling RISC-V Platforms](https://lupyuen.github.io/articles/pr#appendix-building-the-docker-image-for-nuttx-ci)?

### Fixes for Ubuntu x64

```bash
## TODO: Install Docker Engine: https://docs.docker.com/engine/install/ubuntu/
## TODO: Apply this fix: https://stackoverflow.com/questions/48957195/how-to-fix-docker-got-permission-denied-issue
## Note: podman won't work

## NuttX CI needs to save files in `/github`, so we create it
## TODO: How to give each runner its own `/github` folder? Do we mount in Docker?
mkdir -p $HOME/github/home
mkdir -p $HOME/github/workspace
sudo ln -s $HOME/github /github
ls -l /github/home

## TODO: Clean up after every job, then restart the runner
sudo rm -rf $HOME/actions-runner/_work/runner-nuttx
cd $HOME/actions-runner
./run.sh

## TODO: In case of timeout after 6 hours:
## Restart the Ubuntu Machine, because the tasks are still running in background!
```

### Fixes for macOS Arm64

```bash
sudo mkdir /Users/runner
sudo chown $USER /Users/runner
sudo chgrp staff /Users/runner
ls -ld /Users/runner

## Maybe need pip?
brew install python
```

### Ubuntu x64 Runner In Action

__macOS Arm64 with UTM Emulation:__

On a powerful Mac Mini (M2 Pro, 32 GB RAM): We can emulate an Intel i7 PC with 32 CPUs and 4 GB RAM (we don't need much RAM)

![Screenshot 2024-08-29 at 10 08 07 PM](https://github.com/user-attachments/assets/5ff0d94e-4a04-4cf4-8f0a-8e0ee9d1cd59)

![Screenshot 2024-08-29 at 10 08 25 PM](https://github.com/user-attachments/assets/3a162236-9c14-4615-b9c7-c3a90ef7293c)

Ubuntu Disk Space in UTM VM needs to be big enough for NuttX Docker Image:

```text
user@ubuntu-emu-arm64:~$ neofetch
            .-/+oossssoo+/-.               user@ubuntu-emu-arm64
        `:+ssssssssssssssssss+:`           ---------------------
      -+ssssssssssssssssssyyssss+-         OS: Ubuntu 24.04.1 LTS x86_64
    .ossssssssssssssssssdMMMNysssso.       Host: KVM/QEMU (Standard PC (Q35 + ICH9, 2009) pc-q35-7.2)
   /ssssssssssshdmmNNmmyNMMMMhssssss/      Kernel: 6.8.0-41-generic
  +ssssssssshmydMMMMMMMNddddyssssssss+     Uptime: 1 min
 /sssssssshNMMMyhhyyyyhmNMMMNhssssssss/    Packages: 1546 (dpkg), 10 (snap)
.ssssssssdMMMNhsssssssssshNMMMdssssssss.   Shell: bash 5.2.21
+sssshhhyNMMNyssssssssssssyNMMMysssssss+   Resolution: 1280x800
ossyNMMMNyMMhsssssssssssssshmmmhssssssso   Terminal: /dev/pts/1
ossyNMMMNyMMhsssssssssssssshmmmhssssssso   CPU: Intel i7 9xx (Nehalem i7, IBRS update) (16) @ 1.000GHz
+sssshhhyNMMNyssssssssssssyNMMMysssssss+   GPU: 00:02.0 Red Hat, Inc. Virtio 1.0 GPU
.ssssssssdMMMNhsssssssssshNMMMdssssssss.   Memory: 1153MiB / 3907MiB
 /sssssssshNMMMyhhyyyyhdNMMMNhssssssss/
  +sssssssssdmydMMMMMMMMddddyssssssss+
   /ssssssssssshdmNNNNmyNMMMMhssssss/
    .ossssssssssssssssssdMMMNysssso.
      -+sssssssssssssssssyyyssss+-
        `:+ssssssssssssssssss+:`
            .-/+oossssoo+/-.

user@ubuntu-emu-arm64:~$ df -H
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           410M  1.7M  409M   1% /run
/dev/sda2        67G   31G   33G  49% /
tmpfs           2.1G     0  2.1G   0% /dev/shm
tmpfs           5.3M  8.2k  5.3M   1% /run/lock
efivarfs        263k   57k  201k  23% /sys/firmware/efi/efivars
/dev/sda1       1.2G  6.5M  1.2G   1% /boot/efi
tmpfs           410M  115k  410M   1% /run/user/1000
```

During `Download Source Artifact`: GitHub seems to be throttling the download (total 700 MB over 25 mins)

![Screenshot 2024-08-29 at 2 09 11 PM](https://github.com/user-attachments/assets/585bc261-bc39-4be4-8515-85894254aace)

During `Run Builds`: CPU hits 100%

![Screenshot 2024-08-29 at 4 56 06 PM](https://github.com/user-attachments/assets/60d4d3eb-d075-49c9-b3ac-bcfa74150668)

Note: Don't leave System Monitor running, it consumes quite a bit of CPU!

Why emulate 32 CPUs? That's because we want to max out the macOS Arm64 CPU Utilisation. Here's our chance to watch Mac Mini run smokin' hot!

![Screenshot 2024-08-30 at 4 14 05 PM](https://github.com/user-attachments/assets/bfd51e51-1bee-49c2-88a3-01698d51d8a4)

![Screenshot 2024-08-30 at 4 14 20 PM](https://github.com/user-attachments/assets/a9dab4fd-a59f-4348-a3f7-397973797288)

![Screenshot 2024-08-29 at 10 43 39 PM](https://github.com/user-attachments/assets/0ea9f33e-1e6f-412a-8f56-6f40dee7f699)

Here's how it runs:

```text
user@ubuntu-emu-arm64:~$ cd actions-runner/
user@ubuntu-emu-arm64:~/actions-runner$ sudo rm -rf _work/runner-nuttx
[sudo] password for user: 
user@ubuntu-emu-arm64:~/actions-runner$ df -H
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           410M  1.7M  408M   1% /run
/dev/sda2        67G   28G   35G  45% /
tmpfs           2.1G     0  2.1G   0% /dev/shm
tmpfs           5.3M  8.2k  5.3M   1% /run/lock
efivarfs        263k  130k  128k  51% /sys/firmware/efi/efivars
/dev/sda1       1.2G  6.5M  1.2G   1% /boot/efi
tmpfs           410M  119k  410M   1% /run/user/1000
user@ubuntu-emu-arm64:~/actions-runner$ ./run.sh 

\u221a Connected to GitHub
Current runner version: '2.319.1'
2024-08-30 02:33:17Z: Listening for Jobs
2024-08-30 02:33:23Z: Running job: Linux (arm-04)
2024-08-30 06:47:38Z: Job Linux (arm-04) completed with result: Succeeded
2024-08-30 06:47:43Z: Running job: Linux (arm-01)
```

Runner Options:

```text
$ ./run.sh --help
Commands:
 ./config.sh         Configures the runner
 ./config.sh remove  Unconfigures the runner
 ./run.sh            Runs the runner interactively. Does not require any options.

Options:
 --help     Prints the help for each command
 --version  Prints the runner version
 --commit   Prints the runner commit
 --check    Check the runner's network connectivity with GitHub server

Config Options:
 --unattended           Disable interactive prompts for missing arguments. Defaults will be used for missing options
 --url string           Repository to add the runner to. Required if unattended
 --token string         Registration token. Required if unattended
 --name string          Name of the runner to configure (default ubuntu-emu-arm64)
 --runnergroup string   Name of the runner group to add this runner to (defaults to the default runner group)
 --labels string        Custom labels that will be added to the runner. This option is mandatory if --no-default-labels is used.
 --no-default-labels    Disables adding the default labels: 'self-hosted,Linux,X64'
 --local                Removes the runner config files from your local machine. Used as an option to the remove command
 --work string          Relative runner work directory (default _work)
 --replace              Replace any existing runner with the same name (default false)
 --pat                  GitHub personal access token with repo scope. Used for checking network connectivity when executing `./run.sh --check`
 --disableupdate        Disable self-hosted runner automatic update to the latest released version`
 --ephemeral            Configure the runner to only take one job and then let the service un-configure the runner after the job finishes (default false)

Examples:
 Check GitHub server network connectivity:
  ./run.sh --check --url <url> --pat <pat>
 Configure a runner non-interactively:
  ./config.sh --unattended --url <url> --token <token>
 Configure a runner non-interactively, replacing any existing runner with the same name:
  ./config.sh --unattended --url <url> --token <token> --replace [--name <name>]
 Configure a runner non-interactively with three extra labels:
  ./config.sh --unattended --url <url> --token <token> --labels L1,L2,L3
Runner listener exit with 0 return code, stop the service, no retry needed.
Exiting runner...
```

__MacBook Pro x64 with Ubuntu:__

Ubuntu CPU on MacBook Pro hits 100% when running the Linux Build for NuttX CI: [Build for arm-02](https://github.com/lupyuen3/runner-nuttx/actions/runs/10591125185/job/29349060343)

![linux-build](https://github.com/user-attachments/assets/2e2861bc-6af0-48f4-b3a1-d0083cd23155)
